### PR TITLE
Use the correct repository for ohmyzsh

### DIFF
--- a/base/core/core.zsh
+++ b/base/core/core.zsh
@@ -180,7 +180,7 @@ __zplug::core::core::variable()
 
     typeset -gx    _ZPLUG_VERSION="2.4.2"
     typeset -gx    _ZPLUG_URL="https://github.com/zplug/zplug"
-    typeset -gx    _ZPLUG_OHMYZSH="robbyrussell/oh-my-zsh"
+    typeset -gx    _ZPLUG_OHMYZSH="ohmyzsh/ohmyzsh"
     typeset -gx    _ZPLUG_PREZTO="sorin-ionescu/prezto"
     typeset -gx    _ZPLUG_AWKPATH="$ZPLUG_ROOT/misc/contrib"
 


### PR DESCRIPTION
The oh-my-zsh moved into its own repository. The "old" repo url is for now being redirected, but I think playing it safe with using the proper url would be better.

Cheers.